### PR TITLE
add schema.table name format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-sql-parse",
-  "version": "0.1.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2",
+        "balanced-match": "^0.4.1",
         "concat-map": "0.0.1"
       }
     },
@@ -37,7 +37,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
@@ -84,12 +84,12 @@
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-readlink": {
@@ -116,8 +116,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -138,8 +138,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -172,9 +172,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -195,9 +195,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "minimatch": {
@@ -206,7 +206,7 @@
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.7"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -259,9 +259,9 @@
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.9.0.tgz",
       "integrity": "sha1-SW365WslYkHkMpp20yRT/cx0si0=",
       "requires": {
-        "nomnom": "1.6.2",
-        "railroad-diagrams": "1.0.0",
-        "randexp": "0.4.5"
+        "nomnom": "~1.6.2",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "^0.4.2"
       },
       "dependencies": {
         "nomnom": {
@@ -269,8 +269,8 @@
           "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
           "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
           "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.4.4"
+            "colors": "0.5.x",
+            "underscore": "~1.4.4"
           }
         },
         "underscore": {
@@ -286,7 +286,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -306,7 +306,7 @@
       "integrity": "sha1-/+OoDD9mbNceawCOR35YTBoy/z4=",
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "0.1.14"
+        "ret": "~0.1.10"
       }
     },
     "ret": {
@@ -320,7 +320,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "wrappy": {

--- a/sql.ne
+++ b/sql.ne
@@ -149,6 +149,7 @@ identifier_comma_list ->
 table ->
     identifier {% d => ({type: 'table', table: d[0].value}) %}
   | identifier "." identifier {% d => ({type: 'table', table: d[0].value +'.'+ d[2].value }) %}
+  | identifier "." identifier ( __ AS __ | __ ) identifier {% d => ({type: 'table', table: d[0].value +'.'+ d[2].value, alias: d[4].value }) %}
   | identifier ( __ AS __ | __) identifier {% d => ({type: 'table', table: d[0].value, alias: d[2].value}) %}
 
 where_clause ->

--- a/test/test1.js
+++ b/test/test1.js
@@ -5,39 +5,37 @@ const tests = [
     sql: 'select * from test',
     expected: {
       referencedTables: ['test'],
-      operation: 'select'
+      operation: 'select',
     },
     toSql: '(select * from (`test`))'
-  },
-  {
+  },{
     sql: 'select x from test',
     toSql: '(select `x` from (`test`))',
-    expected: {
-      returnColumns: [
-        {
-          expression: {
-            type: 'identifier',
-            value: 'x'
-          },
-          mappedTo: {
-            column: 'x'
-          },
-          name: 'x',
-          sourceColumns: [
-            {
-              type: 'identifier',
-              value: 'x'
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    sql: ['select * # comments!', 'from -- more comments!', 'test -- hello'].join('\n'),
+		expected: {
+			returnColumns: [{
+				expression: {
+					type: 'identifier',
+					value: 'x'
+				},
+				mappedTo: {
+					column: 'x'
+				},
+				name: 'x',
+				sourceColumns: [{
+					type: 'identifier',
+					value: 'x'
+				}]
+			}]
+		}
+  },{
+    sql: [
+			'select * # comments!',
+			'from -- more comments!',
+			'test -- hello'
+		].join('\n'),
     expected: {
       referencedTables: ['test'],
-      operation: 'select'
+      operation: 'select',
     },
     toSql: '(select * from (`test`))'
   },
@@ -66,7 +64,7 @@ const tests = [
     expected: {
       referencedTables: []
     },
-    toSql: '(select (case when (`x` = 1) then "hello" else "bye" end))'
+    toSql: '(select (case when (`x` = 1) then "hello" else "bye" end))',
   },
   {
     sql: 'select case when x=1 then "x" when x=2 then "y" end',
@@ -81,23 +79,26 @@ const tests = [
     toSql: '(select (case when true then (case when true then 1 end) end) as `v` from (`test_table`))'
   },
   {
-    sql: 'select x, sum(1) AS `count` from y left join x on (a.foo=b.foo)',
+    sql: 'select x, sum(1) AS \`count\` from y left join x on (a.foo=b.foo)',
     toSql: '(select `x`, sum(1) as `count` from ((`y` left join `x` on (`a`.`foo` = `b`.`foo`))))',
     expected: {
       joins: [
         {
-          right: { type: 'table', table: 'x' },
-          columns: [{ name: 'foo', type: 'column', table: 'a' }, { name: 'foo', type: 'column', table: 'b' }]
+          right: {type: 'table', table: 'x'},
+          columns: [
+            {name: 'foo', type: 'column', table:'a'},
+            {name: 'foo', type: 'column', table:'b'}
+          ]
         }
       ]
     }
   },
   {
     sql: 'select x from ((test))',
-    expected: {
+    expected:  {
       referencedTables: ['test']
     },
-    toSql: '(select `x` from (`test`))'
+    toSql: '(select `x` from (`test`))',
   },
   {
     sql: 'select x and y and z from l',
@@ -112,8 +113,8 @@ const tests = [
     toSql: '(select replace(substr("test", 10), "a", "") as `testing`)'
   },
   {
-    sql: 'select sum(if(`this`.`name`=`mapping`, 0, 1))',
-    toSql: '(select sum(if((`this`.`name` = `mapping`), 0, 1)))'
+    sql: "select sum(if(`this`.`name`=`mapping`, 0, 1))",
+    toSql: "(select sum(if((`this`.`name` = `mapping`), 0, 1)))"
   },
   {
     sql: 'select (select * from x) as x',
@@ -148,14 +149,12 @@ const tests = [
     toSql: '(select * from (`a`) group by (`a`.`x`))'
   },
   {
-    sql:
-      'select `a`.`b` AS `c`,(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) AS `month`,sum(`a`.`b`) AS `a`,sum(`a`.`b`) AS `c`,cast(substr(max(concat(`x`.`y`,`x`.`total`)),11) as signed) AS `a` from `b` group by `a`.`a`,(`a`.`b` - interval (dayofmonth(`x`.`y`) - 1) day)',
-    toSql:
-      '(select `a`.`b` as `c`, ' +
-      '(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) as `month`, ' +
-      'sum(`a`.`b`) as `a`, ' +
-      'sum(`a`.`b`) as `c`, ' +
-      'cast(substr(max(concat(`x`.`y`, `x`.`total`)), 11) as signed) as `a` ' +
+    sql: 'select `a`.`b` AS `c`,(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) AS `month`,sum(`a`.`b`) AS `a`,sum(`a`.`b`) AS `c`,cast(substr(max(concat(`x`.`y`,`x`.`total`)),11) as signed) AS `a` from `b` group by `a`.`a`,(`a`.`b` - interval (dayofmonth(`x`.`y`) - 1) day)',
+    toSql: '(select `a`.`b` as `c`, '+
+      '(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) as `month`, '+
+      'sum(`a`.`b`) as `a`, '+
+      'sum(`a`.`b`) as `c`, '+
+      'cast(substr(max(concat(`x`.`y`, `x`.`total`)), 11) as signed) as `a` '+
       'from (`b`) group by (`a`.`a`, (`a`.`b` - interval (dayofmonth(`x`.`y`) - 1) day)))'
   },
   {
@@ -184,145 +183,134 @@ const tests = [
     toSql: '(select DaTe() as `X`)'
   },
   {
-    sql:
-      'select count(*) as count, FROM_DAYS(TO_DAYS(`modified_at`)-MOD(TO_DAYS(`modified_at`) -1, 7)) as ts from job group by ts',
-    toSql:
-      '(select count(*) as `count`, FROM_DAYS((TO_DAYS(`modified_at`) - MOD((TO_DAYS(`modified_at`) - 1), 7))) as `ts` from (`job`) group by (`ts`))'
+    sql: "select count(*) as count, FROM_DAYS(TO_DAYS(`modified_at`)-MOD(TO_DAYS(`modified_at`) -1, 7)) as ts from job group by ts",
+    toSql: '(select count(*) as `count`, FROM_DAYS((TO_DAYS(`modified_at`) - MOD((TO_DAYS(`modified_at`) - 1), 7))) as `ts` from (`job`) group by (`ts`))'
   },
   {
-    sql: 'select cast(x as float)',
+    sql: "select cast(x as float)",
     toSql: '(select cast(`x` as float))'
   },
   {
-    sql: 'select top 10 x from test_table',
-    toSql: '(select top 10 `x` from (`test_table`))'
+    sql: "select top 10 x from test_table",
+    toSql: "(select top 10 `x` from (`test_table`))"
   },
   {
-    sql: 'select cast(x as decimal) as y',
-    toSql: '(select cast(`x` as decimal) as `y`)'
+    sql: "select cast(x as decimal) as y",
+    toSql: "(select cast(`x` as decimal) as `y`)"
   },
   {
-    sql: 'select cast(x as decimal) as y#comment',
-    toSql: '(select cast(`x` as decimal) as `y`)'
+    sql: "select cast(x as decimal) as y#comment",
+    toSql: "(select cast(`x` as decimal) as `y`)"
   },
-  {
-    sql: 'select cast(x as decimal); ',
-    toSql: '(select cast(`x` as decimal))'
+	{
+    sql: "select cast(x as decimal); ",
+    toSql: "(select cast(`x` as decimal))"
   },
   {
     sql: 'select x.y>DATE_SUB(CURDATE(),INTERVAL 7 day) -- comments',
-    toSql: '(select (`x`.`y` > DATE_SUB(CURDATE(), interval 7 day)))'
+    toSql: "(select (`x`.`y` > DATE_SUB(CURDATE(), interval 7 day)))"
   },
-  {
-    sql: `select x, sum(y), count(*) from test group by x, sum(y) with rollup`,
-    toSql: '(select `x`, sum(`y`), count(*) from (`test`) group by (`x`, sum(`y`)) with rollup)'
-  },
-  {
-    sql: `select a.x,b.y from a left join (select x,y from c) b on a.x=b.x`,
-    toSql:
-      '(select `a`.`x`, `b`.`y` from ((`a` left join (select `x`, `y` from (`c`)) as `b` on (`a`.`x` = `b`.`x`))))',
-    expected: {
-      sourceTables: ['a', 'c']
-    }
-  },
-  {
-    sql: `select a.x, b.y from a left join b using (x)`,
-    toSql: '(select `a`.`x`, `b`.`y` from ((`a` left join `b` using (`x`))))',
-    expected: {
-      aliases: {
-        a: 'a',
-        b: 'b'
-      }
-    }
-  },
-  {
-    sql: `select a.x, b.y from c as a left join d as b using (z)`,
-    toSql: '(select `a`.`x`, `b`.`y` from ((`c`as `a` left join `d`as `b` using (`z`))))',
-    expected: {
-      aliases: {
-        a: 'c',
-        b: 'd'
-      }
-    }
-  },
-  {
-    sql: 'select x, y -- testing\n\tfrom x\n-- help',
-    toSql: '(select `x`, `y` from (`x`))'
-  },
-  {
-    sql: `select binary x=y from t`,
-    toSql: '(select (binary (`x`) = `y`) from (`t`))'
-  },
-  {
-    sql: 'select x <=> z from y',
-    toSql: '(select (`x` <=> `z`) from (`y`))'
-  },
-  {
-    sql: `select a from b where d`,
-    toSql: '(select `a` from (`b`) where (`d`))',
-    expected: {
-      returnColumns: [
-        {
-          expression: {
-            type: 'identifier',
-            value: 'a'
-          },
-          name: 'a',
-          mappedTo: {
-            column: 'a'
-          },
-          sourceColumns: [
-            {
-              type: 'identifier',
-              value: 'a'
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    sql: `select a from x where (z or not b)`,
-    toSql: '(select `a` from (`x`) where ((`z` or (not `b`))))'
-  },
-  {
-    sql: `select not a or b from x`,
-    toSql: '(select ((not `a`) or `b`) from (`x`))'
-  },
-  {
-    sql: `select not (a or b) from x`,
-    toSql: '(select (not (`a` or `b`)) from (`x`))'
-  },
-  {
-    sql: 'select a from b where (c or not d) and e is not null and f',
-    toSql: '(select `a` from (`b`) where ((((`c` or (not `d`)) and (`e` is not null)) and `f`)))'
-  },
-  {
-    sql: 'select a.x from b',
-    toSql: '(select `a`.`x` from (`b`))',
-    expected: {
-      returnColumns: [
-        {
-          expression: {
-            type: 'column',
-            table: 'a',
-            name: 'x'
-          },
-          name: 'x',
-          mappedTo: {
-            column: 'x',
-            table: 'a'
-          },
-          sourceColumns: [
-            {
-              type: 'column',
-              table: 'a',
-              name: 'x'
-            }
-          ]
-        }
-      ]
-    }
+	{
+		sql: `select x, sum(y), count(*) from test group by x, sum(y) with rollup`,
+		toSql: '(select `x`, sum(`y`), count(*) from (`test`) group by (`x`, sum(`y`)) with rollup)'
+	},
+	{
+		sql: `select a.x,b.y from a left join (select x,y from c) b on a.x=b.x`,
+		toSql: '(select `a`.`x`, `b`.`y` from ((`a` left join (select `x`, `y` from (`c`)) as `b` on (`a`.`x` = `b`.`x`))))',
+		expected: {
+			sourceTables: ['a','c']
+		}
+	},
+	{
+		sql: `select a.x, b.y from a left join b using (x)`,
+		toSql: '(select `a`.`x`, `b`.`y` from ((`a` left join `b` using (`x`))))',
+		expected: {
+			aliases: {
+				a:'a',
+				b:'b'
+			}
+		}
+	},
+	{
+		sql: `select a.x, b.y from c as a left join d as b using (z)`,
+		toSql: '(select `a`.`x`, `b`.`y` from ((`c`as `a` left join `d`as `b` using (`z`))))',
+		expected: {
+			aliases: {
+				a:'c',
+				b:'d'
+			}
+		}
+	},
+	{
+		sql:'select x, y -- testing\n\tfrom x\n-- help',
+		toSql: '(select `x`, `y` from (`x`))'
+	},
+	{
+		sql:`select binary x=y from t`,
+		toSql: '(select (binary (`x`) = `y`) from (`t`))'
+	},
+	{
+		sql: 'select x <=> z from y',
+		toSql: '(select (`x` <=> `z`) from (`y`))'
+	},
+	{
+		sql: `select a from b where d`,
+		toSql: '(select `a` from (`b`) where (`d`))',
+		expected: {
+			returnColumns: [{
+				expression: {
+					type: 'identifier',
+					value: 'a',
+				},
+				name: 'a',
+				mappedTo: {
+					column: 'a'
+				},
+				sourceColumns: [{
+					type: 'identifier',
+					value: 'a'
+				}]
+			}]
+		}
+	},
+	{
+		sql: `select a from x where (z or not b)`,
+		toSql: '(select `a` from (`x`) where ((`z` or (not `b`))))'
+	},
+	{
+		sql: `select not a or b from x`,
+		toSql: '(select ((not `a`) or `b`) from (`x`))'
+	},
+	{
+		sql: `select not (a or b) from x`,
+		toSql: '(select (not (`a` or `b`)) from (`x`))'
+	},
+	{
+		sql: 'select a from b where (c or not d) and e is not null and f',
+		toSql: '(select `a` from (`b`) where ((((`c` or (not `d`)) and (`e` is not null)) and `f`)))'
+	},
+	{
+		sql: 'select a.x from b',
+		toSql: '(select `a`.`x` from (`b`))',
+		expected: {
+			returnColumns: [{
+				expression: {
+					type: 'column',
+					table: 'a',
+					name: 'x'
+				},
+				name: 'x',
+				mappedTo: {
+					column: 'x',
+					table: 'a'
+				},
+				sourceColumns: [{
+					type: 'column',
+					table: 'a',
+					name: 'x'
+				}]
+			}]
+		}
   },
   {
     sql: `select a.x, b.y from s.c a left join s.d as b on a.x=b.x`,
@@ -352,26 +340,24 @@ const parser = require('../parser')();
 
 describe('parse', function() {
   tests.map(t => {
-    describe(t.sql.slice(0, 100), function() {
+    describe(t.sql.slice(0,100), function() {
       try {
         const parsed = parser.parse(t.sql);
-        it('parse', function() {});
+        it('parse', function() { });
 
-        for (let e in t.expected) {
-          it(e + ' = ' + JSON.stringify(t.expected[e]), function() {
+        for(let e in t.expected) {
+          it(e + " = " + JSON.stringify(t.expected[e]), function() {
             assert.deepEqual(t.expected[e], parsed[e]);
           });
         }
 
         it('toSql = ' + t.toSql, function() {
-          const toSql = parser.toSql(parsed.parsed);
+          const toSql=parser.toSql(parsed.parsed);
           assert.equal(t.toSql, toSql);
         });
-      } catch (e) {
-        it('parse', function() {
-          assert.fail(e);
-        });
+      } catch(e) {
+        it('parse', function() { assert.fail(e); });
       }
     });
-  });
+  })
 });

--- a/test/test1.js
+++ b/test/test1.js
@@ -5,37 +5,39 @@ const tests = [
     sql: 'select * from test',
     expected: {
       referencedTables: ['test'],
-      operation: 'select',
+      operation: 'select'
     },
     toSql: '(select * from (`test`))'
-  },{
+  },
+  {
     sql: 'select x from test',
     toSql: '(select `x` from (`test`))',
-		expected: {
-			returnColumns: [{
-				expression: {
-					type: 'identifier',
-					value: 'x'
-				},
-				mappedTo: {
-					column: 'x'
-				},
-				name: 'x',
-				sourceColumns: [{
-					type: 'identifier',
-					value: 'x'
-				}]
-			}]
-		}
-  },{
-    sql: [
-			'select * # comments!',
-			'from -- more comments!',
-			'test -- hello'
-		].join('\n'),
+    expected: {
+      returnColumns: [
+        {
+          expression: {
+            type: 'identifier',
+            value: 'x'
+          },
+          mappedTo: {
+            column: 'x'
+          },
+          name: 'x',
+          sourceColumns: [
+            {
+              type: 'identifier',
+              value: 'x'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    sql: ['select * # comments!', 'from -- more comments!', 'test -- hello'].join('\n'),
     expected: {
       referencedTables: ['test'],
-      operation: 'select',
+      operation: 'select'
     },
     toSql: '(select * from (`test`))'
   },
@@ -64,7 +66,7 @@ const tests = [
     expected: {
       referencedTables: []
     },
-    toSql: '(select (case when (`x` = 1) then "hello" else "bye" end))',
+    toSql: '(select (case when (`x` = 1) then "hello" else "bye" end))'
   },
   {
     sql: 'select case when x=1 then "x" when x=2 then "y" end',
@@ -79,26 +81,23 @@ const tests = [
     toSql: '(select (case when true then (case when true then 1 end) end) as `v` from (`test_table`))'
   },
   {
-    sql: 'select x, sum(1) AS \`count\` from y left join x on (a.foo=b.foo)',
+    sql: 'select x, sum(1) AS `count` from y left join x on (a.foo=b.foo)',
     toSql: '(select `x`, sum(1) as `count` from ((`y` left join `x` on (`a`.`foo` = `b`.`foo`))))',
     expected: {
       joins: [
         {
-          right: {type: 'table', table: 'x'},
-          columns: [
-            {name: 'foo', type: 'column', table:'a'},
-            {name: 'foo', type: 'column', table:'b'}
-          ]
+          right: { type: 'table', table: 'x' },
+          columns: [{ name: 'foo', type: 'column', table: 'a' }, { name: 'foo', type: 'column', table: 'b' }]
         }
       ]
     }
   },
   {
     sql: 'select x from ((test))',
-    expected:  {
+    expected: {
       referencedTables: ['test']
     },
-    toSql: '(select `x` from (`test`))',
+    toSql: '(select `x` from (`test`))'
   },
   {
     sql: 'select x and y and z from l',
@@ -113,8 +112,8 @@ const tests = [
     toSql: '(select replace(substr("test", 10), "a", "") as `testing`)'
   },
   {
-    sql: "select sum(if(`this`.`name`=`mapping`, 0, 1))",
-    toSql: "(select sum(if((`this`.`name` = `mapping`), 0, 1)))"
+    sql: 'select sum(if(`this`.`name`=`mapping`, 0, 1))',
+    toSql: '(select sum(if((`this`.`name` = `mapping`), 0, 1)))'
   },
   {
     sql: 'select (select * from x) as x',
@@ -149,12 +148,14 @@ const tests = [
     toSql: '(select * from (`a`) group by (`a`.`x`))'
   },
   {
-    sql: 'select `a`.`b` AS `c`,(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) AS `month`,sum(`a`.`b`) AS `a`,sum(`a`.`b`) AS `c`,cast(substr(max(concat(`x`.`y`,`x`.`total`)),11) as signed) AS `a` from `b` group by `a`.`a`,(`a`.`b` - interval (dayofmonth(`x`.`y`) - 1) day)',
-    toSql: '(select `a`.`b` as `c`, '+
-      '(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) as `month`, '+
-      'sum(`a`.`b`) as `a`, '+
-      'sum(`a`.`b`) as `c`, '+
-      'cast(substr(max(concat(`x`.`y`, `x`.`total`)), 11) as signed) as `a` '+
+    sql:
+      'select `a`.`b` AS `c`,(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) AS `month`,sum(`a`.`b`) AS `a`,sum(`a`.`b`) AS `c`,cast(substr(max(concat(`x`.`y`,`x`.`total`)),11) as signed) AS `a` from `b` group by `a`.`a`,(`a`.`b` - interval (dayofmonth(`x`.`y`) - 1) day)',
+    toSql:
+      '(select `a`.`b` as `c`, ' +
+      '(`x`.`y` - interval (dayofmonth(`a`.`b`) - 1) day) as `month`, ' +
+      'sum(`a`.`b`) as `a`, ' +
+      'sum(`a`.`b`) as `c`, ' +
+      'cast(substr(max(concat(`x`.`y`, `x`.`total`)), 11) as signed) as `a` ' +
       'from (`b`) group by (`a`.`a`, (`a`.`b` - interval (dayofmonth(`x`.`y`) - 1) day)))'
   },
   {
@@ -183,159 +184,194 @@ const tests = [
     toSql: '(select DaTe() as `X`)'
   },
   {
-    sql: "select count(*) as count, FROM_DAYS(TO_DAYS(`modified_at`)-MOD(TO_DAYS(`modified_at`) -1, 7)) as ts from job group by ts",
-    toSql: '(select count(*) as `count`, FROM_DAYS((TO_DAYS(`modified_at`) - MOD((TO_DAYS(`modified_at`) - 1), 7))) as `ts` from (`job`) group by (`ts`))'
+    sql:
+      'select count(*) as count, FROM_DAYS(TO_DAYS(`modified_at`)-MOD(TO_DAYS(`modified_at`) -1, 7)) as ts from job group by ts',
+    toSql:
+      '(select count(*) as `count`, FROM_DAYS((TO_DAYS(`modified_at`) - MOD((TO_DAYS(`modified_at`) - 1), 7))) as `ts` from (`job`) group by (`ts`))'
   },
   {
-    sql: "select cast(x as float)",
+    sql: 'select cast(x as float)',
     toSql: '(select cast(`x` as float))'
   },
   {
-    sql: "select top 10 x from test_table",
-    toSql: "(select top 10 `x` from (`test_table`))"
+    sql: 'select top 10 x from test_table',
+    toSql: '(select top 10 `x` from (`test_table`))'
   },
   {
-    sql: "select cast(x as decimal) as y",
-    toSql: "(select cast(`x` as decimal) as `y`)"
+    sql: 'select cast(x as decimal) as y',
+    toSql: '(select cast(`x` as decimal) as `y`)'
   },
   {
-    sql: "select cast(x as decimal) as y#comment",
-    toSql: "(select cast(`x` as decimal) as `y`)"
+    sql: 'select cast(x as decimal) as y#comment',
+    toSql: '(select cast(`x` as decimal) as `y`)'
   },
-	{
-    sql: "select cast(x as decimal); ",
-    toSql: "(select cast(`x` as decimal))"
+  {
+    sql: 'select cast(x as decimal); ',
+    toSql: '(select cast(`x` as decimal))'
   },
   {
     sql: 'select x.y>DATE_SUB(CURDATE(),INTERVAL 7 day) -- comments',
-    toSql: "(select (`x`.`y` > DATE_SUB(CURDATE(), interval 7 day)))"
+    toSql: '(select (`x`.`y` > DATE_SUB(CURDATE(), interval 7 day)))'
   },
-	{
-		sql: `select x, sum(y), count(*) from test group by x, sum(y) with rollup`,
-		toSql: '(select `x`, sum(`y`), count(*) from (`test`) group by (`x`, sum(`y`)) with rollup)'
-	},
-	{
-		sql: `select a.x,b.y from a left join (select x,y from c) b on a.x=b.x`,
-		toSql: '(select `a`.`x`, `b`.`y` from ((`a` left join (select `x`, `y` from (`c`)) as `b` on (`a`.`x` = `b`.`x`))))',
-		expected: {
-			sourceTables: ['a','c']
-		}
-	},
-	{
-		sql: `select a.x, b.y from a left join b using (x)`,
-		toSql: '(select `a`.`x`, `b`.`y` from ((`a` left join `b` using (`x`))))',
-		expected: {
-			aliases: {
-				a:'a',
-				b:'b'
-			}
-		}
-	},
-	{
-		sql: `select a.x, b.y from c as a left join d as b using (z)`,
-		toSql: '(select `a`.`x`, `b`.`y` from ((`c`as `a` left join `d`as `b` using (`z`))))',
-		expected: {
-			aliases: {
-				a:'c',
-				b:'d'
-			}
-		}
-	},
-	{
-		sql:'select x, y -- testing\n\tfrom x\n-- help',
-		toSql: '(select `x`, `y` from (`x`))'
-	},
-	{
-		sql:`select binary x=y from t`,
-		toSql: '(select (binary (`x`) = `y`) from (`t`))'
-	},
-	{
-		sql: 'select x <=> z from y',
-		toSql: '(select (`x` <=> `z`) from (`y`))'
-	},
-	{
-		sql: `select a from b where d`,
-		toSql: '(select `a` from (`b`) where (`d`))',
-		expected: {
-			returnColumns: [{
-				expression: {
-					type: 'identifier',
-					value: 'a',
-				},
-				name: 'a',
-				mappedTo: {
-					column: 'a'
-				},
-				sourceColumns: [{
-					type: 'identifier',
-					value: 'a'
-				}]
-			}]
-		}
-	},
-	{
-		sql: `select a from x where (z or not b)`,
-		toSql: '(select `a` from (`x`) where ((`z` or (not `b`))))'
-	},
-	{
-		sql: `select not a or b from x`,
-		toSql: '(select ((not `a`) or `b`) from (`x`))'
-	},
-	{
-		sql: `select not (a or b) from x`,
-		toSql: '(select (not (`a` or `b`)) from (`x`))'
-	},
-	{
-		sql: 'select a from b where (c or not d) and e is not null and f',
-		toSql: '(select `a` from (`b`) where ((((`c` or (not `d`)) and (`e` is not null)) and `f`)))'
-	},
-	{
-		sql: 'select a.x from b',
-		toSql: '(select `a`.`x` from (`b`))',
-		expected: {
-			returnColumns: [{
-				expression: {
-					type: 'column',
-					table: 'a',
-					name: 'x'
-				},
-				name: 'x',
-				mappedTo: {
-					column: 'x',
-					table: 'a'
-				},
-				sourceColumns: [{
-					type: 'column',
-					table: 'a',
-					name: 'x'
-				}]
-			}]
-		}
-	}
+  {
+    sql: `select x, sum(y), count(*) from test group by x, sum(y) with rollup`,
+    toSql: '(select `x`, sum(`y`), count(*) from (`test`) group by (`x`, sum(`y`)) with rollup)'
+  },
+  {
+    sql: `select a.x,b.y from a left join (select x,y from c) b on a.x=b.x`,
+    toSql:
+      '(select `a`.`x`, `b`.`y` from ((`a` left join (select `x`, `y` from (`c`)) as `b` on (`a`.`x` = `b`.`x`))))',
+    expected: {
+      sourceTables: ['a', 'c']
+    }
+  },
+  {
+    sql: `select a.x, b.y from a left join b using (x)`,
+    toSql: '(select `a`.`x`, `b`.`y` from ((`a` left join `b` using (`x`))))',
+    expected: {
+      aliases: {
+        a: 'a',
+        b: 'b'
+      }
+    }
+  },
+  {
+    sql: `select a.x, b.y from c as a left join d as b using (z)`,
+    toSql: '(select `a`.`x`, `b`.`y` from ((`c`as `a` left join `d`as `b` using (`z`))))',
+    expected: {
+      aliases: {
+        a: 'c',
+        b: 'd'
+      }
+    }
+  },
+  {
+    sql: 'select x, y -- testing\n\tfrom x\n-- help',
+    toSql: '(select `x`, `y` from (`x`))'
+  },
+  {
+    sql: `select binary x=y from t`,
+    toSql: '(select (binary (`x`) = `y`) from (`t`))'
+  },
+  {
+    sql: 'select x <=> z from y',
+    toSql: '(select (`x` <=> `z`) from (`y`))'
+  },
+  {
+    sql: `select a from b where d`,
+    toSql: '(select `a` from (`b`) where (`d`))',
+    expected: {
+      returnColumns: [
+        {
+          expression: {
+            type: 'identifier',
+            value: 'a'
+          },
+          name: 'a',
+          mappedTo: {
+            column: 'a'
+          },
+          sourceColumns: [
+            {
+              type: 'identifier',
+              value: 'a'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    sql: `select a from x where (z or not b)`,
+    toSql: '(select `a` from (`x`) where ((`z` or (not `b`))))'
+  },
+  {
+    sql: `select not a or b from x`,
+    toSql: '(select ((not `a`) or `b`) from (`x`))'
+  },
+  {
+    sql: `select not (a or b) from x`,
+    toSql: '(select (not (`a` or `b`)) from (`x`))'
+  },
+  {
+    sql: 'select a from b where (c or not d) and e is not null and f',
+    toSql: '(select `a` from (`b`) where ((((`c` or (not `d`)) and (`e` is not null)) and `f`)))'
+  },
+  {
+    sql: 'select a.x from b',
+    toSql: '(select `a`.`x` from (`b`))',
+    expected: {
+      returnColumns: [
+        {
+          expression: {
+            type: 'column',
+            table: 'a',
+            name: 'x'
+          },
+          name: 'x',
+          mappedTo: {
+            column: 'x',
+            table: 'a'
+          },
+          sourceColumns: [
+            {
+              type: 'column',
+              table: 'a',
+              name: 'x'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    sql: `select a.x, b.y from s.c a left join s.d as b on a.x=b.x`,
+    toSql: '(select `a`.`x`, `b`.`y` from ((`s.c`as `a` left join `s.d`as `b` on (`a`.`x` = `b`.`x`))))',
+    expected: {
+      sourceTables: ['s.c', 's.d'],
+      aliases: {
+        a: 's.c',
+        b: 's.d'
+      }
+    }
+  },
+  {
+    sql: `select a.x, b.y from [s].[c a] a left join s.[d] as b on a.x=b.x`,
+    toSql: '(select `a`.`x`, `b`.`y` from ((`s.c a`as `a` left join `s.d`as `b` on (`a`.`x` = `b`.`x`))))',
+    expected: {
+      sourceTables: ['s.c a', 's.d'],
+      aliases: {
+        a: 's.c a',
+        b: 's.d'
+      }
+    }
+  }
 ];
 
 const parser = require('../parser')();
 
 describe('parse', function() {
   tests.map(t => {
-    describe(t.sql.slice(0,100), function() {
+    describe(t.sql.slice(0, 100), function() {
       try {
         const parsed = parser.parse(t.sql);
-        it('parse', function() { });
+        it('parse', function() {});
 
-        for(let e in t.expected) {
-          it(e + " = " + JSON.stringify(t.expected[e]), function() {
+        for (let e in t.expected) {
+          it(e + ' = ' + JSON.stringify(t.expected[e]), function() {
             assert.deepEqual(t.expected[e], parsed[e]);
           });
         }
 
         it('toSql = ' + t.toSql, function() {
-          const toSql=parser.toSql(parsed.parsed);
+          const toSql = parser.toSql(parsed.parsed);
           assert.equal(t.toSql, toSql);
         });
-      } catch(e) {
-        it('parse', function() { assert.fail(e); });
+      } catch (e) {
+        it('parse', function() {
+          assert.fail(e);
+        });
       }
     });
-  })
+  });
 });


### PR DESCRIPTION
Makes it able to parse the tables with schema names like 
`select * from schemaName.tableName`

Added couple tests to check the updated logic
`select a.x, b.y from s.c a left join s.d as b on a.x=b.x`
`select a.x, b.y from [s].[c a] a left join s.[d] as b on a.x=b.x`


