### PR TITLE
add user function call with schema name

### DIFF
--- a/sql.ne
+++ b/sql.ne
@@ -548,7 +548,7 @@ identifier ->
 
 function_identifier ->
     btstring {% d => ({value:d[0]}) %}
-  | [a-zA-Z_] [a-zA-Z0-9_]:* {% (d,l,reject) => {
+  | [a-zA-Z_] [a-zA-Z0-9_.]:* {% (d,l,reject) => {
     const value = d[0] + d[1].join('');
     if(reserved.indexOf(value.toUpperCase()) != -1 && valid_function_identifiers.indexOf(value.toUpperCase()) == -1) return reject;
     return {value: value};

--- a/test/test1.js
+++ b/test/test1.js
@@ -311,7 +311,18 @@ const tests = [
 				}]
 			}]
 		}
-	}
+  },
+  {
+    sql: `SELECT x = 'x', y = UPPER(a.y), z = a.aUserFunction(a.y) FROM c a GROUP BY a.y`,
+    toSql:
+      '(select (`x` = "x"), (`y` = UPPER(`a`.`y`)), (`z` = a.aUserFunction(`a`.`y`)) from (`c`as `a`) group by (`a`.`y`))',
+    expected: {
+      sourceTables: ['c'],
+      aliases: {
+        a: 'c'
+      }
+    }
+  }
 ];
 
 const parser = require('../parser')();


### PR DESCRIPTION
enables to parse the following query
`SELECT a, schemaName.fnUserFunction(a) FROM testTable`

