### PR TITLE
add user function call with schema name

### DIFF
--- a/sql.ne
+++ b/sql.ne
@@ -549,7 +549,7 @@ identifier ->
 
 function_identifier ->
     btstring {% d => ({value:d[0]}) %}
-  | [a-zA-Z_] [a-zA-Z0-9_]:* {% (d,l,reject) => {
+  | [a-zA-Z_] [a-zA-Z0-9_.]:* {% (d,l,reject) => {
     const value = d[0] + d[1].join('');
     if(reserved.indexOf(value.toUpperCase()) != -1 && valid_function_identifiers.indexOf(value.toUpperCase()) == -1) return reject;
     return {value: value};

--- a/test/test1.js
+++ b/test/test1.js
@@ -333,6 +333,17 @@ const tests = [
         b: 's.d'
       }
     }
+  },
+  {
+    sql: `select x = 'x', y = upper(a.y), z = a.fnUserFunction(a.y) from c a group by a.y`,
+    toSql:
+      '(select (`x` = "x"), (`y` = upper(`a`.`y`)), (`z` = a.fnUserFunction(`a`.`y`)) from (`c`as `a`) group by (`a`.`y`))',
+    expected: {
+      sourceTables: ['c'],
+      aliases: {
+        a: 'c'
+      }
+    }
   }
 ];
 


### PR DESCRIPTION
Hi @justinkenel 
Please check the updated PR. This one should be able to merge with the previous change.

Enables to parse the following query
`SELECT a, schemaName.fnUserFunction(a) FROM testTable`